### PR TITLE
:sparkles: shell: AWS account name completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.2.1 (unreleased)
+## 0.3.0
+
+### Features
+
+* **AWS account name shell completion**: Add shell completion (bash/zsh/fish) for AWS account names.
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ rh-aws-saml-login currently provides the following features (get help with `-h` 
 - No configuration needed
 - Uses Kerberos authentication
 - Open the AWS web console for an account with the `--console` option
+- Shell auto-completion (bash, zsh, and fish) including AWS account names
 - Integrates nicely with the [starship](https://starship.rs)
 
   ```toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rh-aws-saml-login"
-version = "0.2.0"
+version = "0.3.0"
 description = "A CLI tool that allows you to log in and retrieve AWS temporary credentials using Red Hat SAML IDP"
 authors = ["Christian Assing <cassing@redhat.com>"]
 license = "MIT"

--- a/rh_aws_saml_login/__main__.py
+++ b/rh_aws_saml_login/__main__.py
@@ -1,8 +1,12 @@
+import json
+import logging
+from pathlib import Path
+
 import typer
 from rich import print
 
 from rh_aws_saml_login import core
-from rh_aws_saml_login.utils import blend_text
+from rh_aws_saml_login.utils import blend_text, enable_requests_logging
 
 app = typer.Typer(rich_markup_mode="rich")
 BANNER = r"""
@@ -13,13 +17,37 @@ BANNER = r"""
 /_/  /_/ /_/      \__,_/ |__/|__/____/     /____/\__,_/_/ /_/ /_/_/     /_/\____/\__, /_/_/ /_/
                                                                                 /____/
 """
+APP_NAME = "rh-aws-saml-login"
+APP_DIR = Path(typer.get_app_dir(APP_NAME))
+APP_DIR.mkdir(exist_ok=True)
+ACCOUNT_CACHE = APP_DIR / "account_cache.json"
 
 
-@app.command(epilog="Made with :heart: by [blue]https://github.com/app-sre[/]")
+def write_accounts_cache(accounts: list[str]) -> None:
+    """Write accounts cache to disk."""
+    json.dump(accounts, ACCOUNT_CACHE.open("w"))
+
+
+def read_accounts_cache() -> list[str]:
+    """Read accounts cache from disk."""
+    if ACCOUNT_CACHE.exists():
+        return json.load(ACCOUNT_CACHE.open())
+    return []
+
+
+def complete_account(ctx: typer.Context, incomplete: str):
+    names = ctx.params.get("account_name") or []
+    for name in read_accounts_cache():
+        if name.startswith(incomplete) and name not in names:
+            yield name
+
+
+@app.command(epilog="Made with [red]:heart:[/] by [blue]https://github.com/app-sre[/]")
 def cli(  # noqa: PLR0913, PLR0917
     account_name: str = typer.Argument(
         None,
         help="AWS account name. '.' as shortcut to use $AWS_ACCOUNT_NAME.",
+        autocompletion=complete_account,
     ),
     region: str = typer.Option("us-east-1", help="AWS region"),
     debug: bool = typer.Option(False, help="Enable debug mode"),
@@ -32,15 +60,18 @@ def cli(  # noqa: PLR0913, PLR0917
         help="SAML URL",
     ),
 ):
+    """Login to AWS using SAML."""
+    logging.basicConfig(
+        level=logging.INFO if not debug else logging.DEBUG, format="%(message)s"
+    )
     if display_banner:
         print(blend_text(BANNER, (32, 32, 255), (255, 32, 255)))
-    core.main(
-        account_name=account_name,
-        region=region,
-        debug=debug,
-        console=console,
-        saml_url=saml_url,
+    if debug:
+        enable_requests_logging()
+    accounts = core.main(
+        account_name=account_name, region=region, console=console, saml_url=saml_url
     )
+    write_accounts_cache(accounts)
 
 
 if __name__ == "__main__":

--- a/rh_aws_saml_login/core.py
+++ b/rh_aws_saml_login/core.py
@@ -24,11 +24,7 @@ from rich.progress import (
 )
 from tzlocal import get_localzone
 
-from rh_aws_saml_login.utils import (
-    bye,
-    enable_requests_logging,
-    run,
-)
+from rh_aws_saml_login.utils import bye, run
 
 
 @dataclass
@@ -209,18 +205,8 @@ def open_aws_console(account: AwsAccount, credentials: AwsCredentials) -> None:
 
 
 def main(  # noqa: PLR0913, PLR0917
-    account_name: str | None,
-    region: str,
-    debug: bool,
-    console: bool,
-    saml_url: str,
-):
-    logging.basicConfig(
-        level=logging.INFO if not debug else logging.DEBUG, format="%(message)s"
-    )
-    if debug:
-        enable_requests_logging()
-
+    account_name: str | None, region: str, console: bool, saml_url: str
+) -> list[str]:
     with Progress(
         SpinnerColumn(finished_text="✅"),
         TextColumn("[progress.description]{task.description}"),
@@ -265,3 +251,4 @@ def main(  # noqa: PLR0913, PLR0917
     else:
         open_aws_shell(account, credentials, region)
     bye()
+    return [acc.name for acc in aws_accounts]


### PR DESCRIPTION
Shell auto-complete now supports AWS account names, which are cached in `APP_DIR` and updated on each command execution.

