### PR TITLE
Use -s flag for kist which sets exit status based on valid tgt existence

### DIFF
--- a/rh_aws_saml_login/core.py
+++ b/rh_aws_saml_login/core.py
@@ -51,7 +51,7 @@ class AwsCredentials:
 def is_kerberos_ticket_valid() -> bool:
     """Test for a valid kerberos ticket."""
     try:
-        run(["klist", "--test"], check=True)
+        run(["klist", "-s"], check=True)
         return True
     except subprocess.CalledProcessError:
         return False


### PR DESCRIPTION
Fixes https://github.com/app-sre/rh-aws-saml-login/issues/18