### PR TITLE
chore: increase memory for ecosystem-cert-preflight-checks

### DIFF
--- a/.tekton/main-pull-request.yaml
+++ b/.tekton/main-pull-request.yaml
@@ -30,6 +30,15 @@ spec:
     value: .
   - name: target-stage
     value: test
+  taskRunSpecs:
+  - pipelineTaskName: ecosystem-cert-preflight-checks
+    stepSpecs:
+    - name: check-container
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 4Gi
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/main-push.yaml
+++ b/.tekton/main-push.yaml
@@ -31,6 +31,15 @@ spec:
     value: pypi
   - name: additional_secret
     value: app-sre-pypi-credentials
+  taskRunSpecs:
+  - pipelineTaskName: ecosystem-cert-preflight-checks
+    stepSpecs:
+    - name: check-container
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 4Gi
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
The check gets sometimes OOM killed.