### PR TITLE
Replace sys.exit() with ValueError exception in get_aws_accounts()

### DIFF
--- a/rh_aws_saml_login/core.py
+++ b/rh_aws_saml_login/core.py
@@ -91,8 +91,9 @@ def get_aws_accounts(
     p = pq(r.text).xhtml_to_html()
     accounts = p("div.saml-account")
     if not accounts:
-        logger.error("No AWS accounts found: %s", r.text)
-        sys.exit(1)
+        errormsg = f"No AWS accounts found: {r.text}"
+        logger.error(errormsg)
+        raise ValueError(errormsg)
 
     aws_accounts = []
     for account in accounts.items():


### PR DESCRIPTION
See https://github.com/app-sre/rh-aws-saml-login/issues/149 for broader motivation.

I think that low-level functions that are likely to be re-used programmatically should not make application-level decisions (like calling `sys.exit()`). They should raise an exception and let higher-level components decide what to do about those exceptions.

Moreover, `get_aws_accounts()` already explicitly raises exceptions for other expected errors (`r.raise_for_status()`). I think the function should behave consistently for all expected errors: raise an exception (preferred) or call `sys.exit()`.

Notes on implementation details:

* I went for the built-in `ValueError` exception. I think it fits well enough.

* I moved the error message to a variable because of `ruff` [1].

[1] https://docs.astral.sh/ruff/rules/f-string-in-exception/