### PR TITLE
Define Red Hat SAML endpoint in rh_aws_saml_login.const

### DIFF
--- a/rh_aws_saml_login/__main__.py
+++ b/rh_aws_saml_login/__main__.py
@@ -9,7 +9,7 @@ import typer
 from rich import print as rich_print
 
 from rh_aws_saml_login import core
-from rh_aws_saml_login.consts import AwsConsoleService, AwsRegion
+from rh_aws_saml_login.consts import RH_SAML_URL, AwsConsoleService, AwsRegion
 from rh_aws_saml_login.utils import blend_text, enable_requests_logging
 
 app = typer.Typer(rich_markup_mode="rich")
@@ -73,7 +73,7 @@ def cli(  # noqa: PLR0917
         typer.Option(
             help="SAML URL",
         ),
-    ] = "https://auth.redhat.com/auth/realms/EmployeeIDP/protocol/saml/clients/itaws",
+    ] = RH_SAML_URL,
     session_timeout: Annotated[
         int,
         typer.Option(

--- a/rh_aws_saml_login/consts.py
+++ b/rh_aws_saml_login/consts.py
@@ -1,5 +1,9 @@
 from enum import StrEnum
 
+RH_SAML_URL = (
+    "https://auth.redhat.com/auth/realms/EmployeeIDP/protocol/saml/clients/itaws"
+)
+
 
 # boto3.session.Session().get_available_regions("rds")  # noqa: ERA001
 class AwsRegion(StrEnum):


### PR DESCRIPTION
The value was originally defined as a default value of a CLI argument. As such, the value would not be easily available to applications that use `rh-aws-saml-login` programmatically (see https://github.com/app-sre/rh-aws-saml-login/issues/149) and need to pass the value to low-level functions.