### PR TITLE
rh-aws-saml-login as library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.8.0
+
+### Features
+
+* Jupyter notebook support (#149)
+
+### Chore
+
+* Upgrade dependencies
+
 ## 0.7.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Thank you for using rh-aws-saml-login. 🙇‍♂️ Have a great day ahead! ❤
 - Uses Kerberos authentication
 - Open the AWS web console for an account with the `--console` option
 - Assume a role with the `--assume-uid` option
+- Library usage, e.g. in Jupyter notebooks
 - Shell auto-completion (bash, zsh, and fish) including AWS account names
 - Integrates nicely with the [starship](https://starship.rs)
 
@@ -192,6 +193,30 @@ rh-aws-saml-login --console --console-service s3 app-sre
 ```
 
 Opens the AWS web console for the `s3` service in the `app-sre` account.
+
+### Library Usage
+
+`rh-aws-saml-login` is primarily designed to be used as CLI tool. However, it can also be used as library in any Python application or script, e.g., in Jupyter notebooks:
+
+```python
+import boto3
+
+from rh_aws_saml_login import get_aws_credentials
+
+# Get AWS credentials
+aws_credentials = get_aws_credentials(account_name="my-shiny-aws-account-name")
+
+# Use the credentials with boto3
+s3_client = boto3.client(
+    "s3",
+    aws_access_key_id=credentials.access_key,
+    aws_secret_access_key=credentials.secret_key,
+    aws_session_token=credentials.session_token,
+    region_name=credentials.region,
+)
+
+s3_client.list_buckets()
+```
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rh-aws-saml-login"
-version = "0.7.0"
+version = "0.8.0"
 description = "A CLI tool that allows you to log in and retrieve AWS temporary credentials using Red Hat SAML IDP"
 authors = [{ name = "Christian Assing", email = "cassing@redhat.com" }]
 license = { text = "MIT License" }

--- a/rh_aws_saml_login/__init__.py
+++ b/rh_aws_saml_login/__init__.py
@@ -1,5 +1,12 @@
 """Expose the public API of the package."""
 
+from ._api import get_aws_credentials
+from ._exceptions import NoAwsAccountError, NoKerberosTicketError
 from ._models import AwsCredentials
 
-__all__ = ["AwsCredentials"]
+__all__ = [
+    "AwsCredentials",
+    "NoAwsAccountError",
+    "NoKerberosTicketError",
+    "get_aws_credentials",
+]

--- a/rh_aws_saml_login/_api.py
+++ b/rh_aws_saml_login/_api.py
@@ -3,10 +3,10 @@ import logging
 from ._consts import RH_SAML_URL, AwsRegion
 from ._core import (
     assume_role_with_saml,
-    get_aws_account,
     get_aws_accounts,
     get_saml_auth,
     is_kerberos_ticket_valid,
+    select_aws_account,
 )
 from ._exceptions import NoAwsAccountError, NoKerberosTicketError
 from ._models import AwsCredentials
@@ -27,6 +27,6 @@ def get_aws_credentials(
     aws_accounts = get_aws_accounts(
         aws_url, saml_token, session_timeout_seconds, region
     )
-    if not (account := get_aws_account(aws_accounts, account_name)):
+    if not (account := select_aws_account(aws_accounts, account_name)):
         raise NoAwsAccountError(account_name)
     return assume_role_with_saml(account, saml_token)

--- a/rh_aws_saml_login/_api.py
+++ b/rh_aws_saml_login/_api.py
@@ -1,0 +1,32 @@
+import logging
+
+from ._consts import RH_SAML_URL, AwsRegion
+from ._core import (
+    assume_role_with_saml,
+    get_aws_account,
+    get_aws_accounts,
+    get_saml_auth,
+    is_kerberos_ticket_valid,
+)
+from ._exceptions import NoAwsAccountError, NoKerberosTicketError
+from ._models import AwsCredentials
+
+logger = logging.getLogger(__name__)
+
+
+def get_aws_credentials(
+    account_name: str,
+    saml_url: str = RH_SAML_URL,
+    session_timeout_seconds: int = 900,
+    region: str = AwsRegion.US_EAST_1,
+) -> AwsCredentials:
+    """Get AWS credentials for the given account name non-interactively."""
+    if not is_kerberos_ticket_valid():
+        raise NoKerberosTicketError
+    aws_url, saml_token = get_saml_auth(saml_url)
+    aws_accounts = get_aws_accounts(
+        aws_url, saml_token, session_timeout_seconds, region
+    )
+    if not (account := get_aws_account(aws_accounts, account_name)):
+        raise NoAwsAccountError(account_name)
+    return assume_role_with_saml(account, saml_token)

--- a/rh_aws_saml_login/_exceptions.py
+++ b/rh_aws_saml_login/_exceptions.py
@@ -1,0 +1,8 @@
+class NoKerberosTicketError(RuntimeError):
+    def __init__(self) -> None:
+        super().__init__("No valid kerberos ticket found.")
+
+
+class NoAwsAccountError(RuntimeError):
+    def __init__(self, account_name: str) -> None:
+        super().__init__(f"Account not found: {account_name}")

--- a/rh_aws_saml_login/_utils.py
+++ b/rh_aws_saml_login/_utils.py
@@ -3,7 +3,7 @@ import logging
 import os
 import subprocess
 
-from rich import print  # noqa: A004
+from rich import print as rich_print
 from rich.text import Text
 
 
@@ -26,7 +26,7 @@ def blend_text(
 
 
 def bye() -> None:
-    print(
+    rich_print(
         "Thank you for using rh-aws-saml-login. :man_bowing: Have a great day ahead! :red_heart-emoji:"
     )
 

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -1,0 +1,23 @@
+"""Test all public API methods are available."""
+# ruff: noqa: D103, PLC0415
+
+from dataclasses import is_dataclass
+
+
+def test_public_get_aws_credentials() -> None:
+    from rh_aws_saml_login import get_aws_credentials
+
+    assert callable(get_aws_credentials)
+
+
+def test_public_exceptions() -> None:
+    from rh_aws_saml_login import NoAwsAccountError, NoKerberosTicketError
+
+    assert issubclass(NoAwsAccountError, Exception)
+    assert issubclass(NoKerberosTicketError, Exception)
+
+
+def test_public_models() -> None:
+    from rh_aws_saml_login import AwsCredentials
+
+    assert is_dataclass(AwsCredentials)

--- a/uv.lock
+++ b/uv.lock
@@ -547,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "rh-aws-saml-login"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Expose `get_aws_credentials` as public method to be used in Python applications/scripts.

Example:

```python
import boto3

from rh_aws_saml_login import get_aws_credentials

# Get AWS credentials
aws_credentials = get_aws_credentials(account_name="my-shiny-aws-account-name")

# Use the credentials with boto3
s3_client = boto3.client(
    "s3",
    aws_access_key_id=credentials.access_key,
    aws_secret_access_key=credentials.secret_key,
    aws_session_token=credentials.session_token,
    region_name=credentials.region,
)

s3_client.list_buckets()
```

Closes #149
