### PR TITLE
:sparkles: AWS_ACCOUNT_UID env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.1
+
+### Features
+
+* `AWS_ACCOUNT_UID` environment variable
+
 ## 0.8.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Thank you for using rh-aws-saml-login. 🙇‍♂️ Have a great day ahead! ❤
 `rh-aws-saml-login` sets the following environment variables:
 
 - `AWS_ACCOUNT_NAME`: The name/alias of the AWS account
+- `AWS_ACCOUNT_UID`: The uid of the AWS account
 - `AWS_ROLE_NAME`:  The name of the role
 - `AWS_ROLE_ARN`: The ARN of the role
 - `AWS_ACCESS_KEY_ID`: The access key used by the AWS CLI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rh-aws-saml-login"
-version = "0.8.0"
+version = "0.8.1"
 description = "A CLI tool that allows you to log in and retrieve AWS temporary credentials using Red Hat SAML IDP"
 authors = [{ name = "Christian Assing", email = "cassing@redhat.com" }]
 license = { text = "MIT License" }

--- a/rh_aws_saml_login/_cli.py
+++ b/rh_aws_saml_login/_cli.py
@@ -74,6 +74,7 @@ def open_aws_shell(
         capture_output=False,
         env={
             "AWS_ACCOUNT_NAME": account.name,
+            "AWS_ACCOUNT_UID": account.uid,
             "AWS_ROLE_NAME": account.role_name,
             "AWS_ROLE_ARN": account.role_arn,
             "AWS_ACCESS_KEY_ID": credentials.access_key,

--- a/uv.lock
+++ b/uv.lock
@@ -551,7 +551,7 @@ wheels = [
 
 [[package]]
 name = "rh-aws-saml-login"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Expose the account uid via the `AWS_ACCOUNT_UID` environment variable.

Closes #225
