### PR TITLE
:green_heart: ci: add service account

### DIFF
--- a/.tekton/main-pull-request.yaml
+++ b/.tekton/main-pull-request.yaml
@@ -39,7 +39,8 @@ spec:
       value: main
     - name: pathInRepo
       value: pipelines/multi-arch-build-pipeline.yaml
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-rh-aws-saml-login-main
   workspaces:
   - name: workspace
     volumeClaimTemplate:

--- a/.tekton/main-push.yaml
+++ b/.tekton/main-push.yaml
@@ -40,7 +40,8 @@ spec:
       value: main
     - name: pathInRepo
       value: pipelines/multi-arch-build-pipeline.yaml
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-rh-aws-saml-login-main
   workspaces:
   - name: workspace
     volumeClaimTemplate:


### PR DESCRIPTION
Konflux will decommission the currently used common service account. Now every project must use its own via `serviceAccountName`. See https://groups.google.com/a/redhat.com/g/konflux-announce/c/NxOyzi8wGxo


Ticket: [APPSRE-11861](https://issues.redhat.com/browse/APPSRE-11861)