### PR TITLE
Fix region default value

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rh-aws-saml-login"
-version = "0.8.1"
+version = "0.8.2"
 description = "A CLI tool that allows you to log in and retrieve AWS temporary credentials using Red Hat SAML IDP"
 authors = [{ name = "Christian Assing", email = "cassing@redhat.com" }]
 license = { text = "MIT License" }

--- a/rh_aws_saml_login/_cli.py
+++ b/rh_aws_saml_login/_cli.py
@@ -149,6 +149,14 @@ def version_callback(*, value: bool) -> None:
         raise typer.Exit
 
 
+def region_callback(region: str) -> str:
+    if region not in AwsRegion:
+        rich_print(f"{region} not in {[r.value for r in AwsRegion]}")
+        raise typer.Exit
+
+    return region
+
+
 @app.command(epilog="Made with [red]:heart:[/] by [blue]https://github.com/app-sre[/]")
 def cli(  # noqa: PLR0917
     account_name: Annotated[
@@ -160,12 +168,13 @@ def cli(  # noqa: PLR0917
     ] = None,
     command: Annotated[list[str] | None, typer.Argument(help="Command to run")] = None,
     region: Annotated[
-        AwsRegion,
+        str,
         typer.Option(
             help="AWS region",
             envvar="RH_AWS_REGION",
+            callback=region_callback,
         ),
-    ] = AwsRegion.US_EAST_1,
+    ] = AwsRegion.US_EAST_1.value,
     saml_url: Annotated[
         str,
         typer.Option(

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11"
 
 [[package]]
@@ -553,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "rh-aws-saml-login"
-version = "0.8.1"
+version = "0.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
the tool breaks without this

```
[rporresm@rporresm-mac ~]$ rh-aws-saml-login
╭──────────────────────────────────────────────────────────────────────────────────────────────────── Traceback (most recent call last) ─────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/click/types.py:348 in convert                                                                                                                         │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
StopIteration

During handling of the above exception, another exception occurred:

╭──────────────────────────────────────────────────────────────────────────────────────────────────── Traceback (most recent call last) ─────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/typer/core.py:194 in _main                                                                                                                            │
│                                                                                                                                                                                                                                            │
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/click/core.py:1186 in make_context                                                                                                                    │
│                                                                                                                                                                                                                                            │
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/click/core.py:1197 in parse_args                                                                                                                      │
│                                                                                                                                                                                                                                            │
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/click/core.py:2416 in handle_parse_result                                                                                                             │
│                                                                                                                                                                                                                                            │
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/click/core.py:2349 in process_value                                                                                                                   │
│                                                                                                                                                                                                                                            │
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/click/core.py:2337 in type_cast_value                                                                                                                 │
│                                                                                                                                                                                                                                            │
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/click/core.py:2309 in convert                                                                                                                         │
│                                                                                                                                                                                                                                            │
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/click/types.py:90 in __call__                                                                                                                         │
│                                                                                                                                                                                                                                            │
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/click/types.py:354 in convert                                                                                                                         │
│                                                                                                                                                                                                                                            │
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/click/types.py:143 in fail                                                                                                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
BadParameter: <AwsRegion.US_EAST_1: 'us-east-1'> is not one of 'af-south-1', 'ap-east-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-northeast-3', 'ap-south-1', 'ap-south-2', 'ap-southeast-1', 'ap-southeast-2', 'ap-southeast-3',
'ap-southeast-4', 'ap-southeast-5', 'ca-central-1', 'ca-west-1', 'eu-central-1', 'eu-central-2', 'eu-north-1', 'eu-south-1', 'eu-south-2', 'eu-west-1', 'eu-west-2', 'eu-west-3', 'il-central-1', 'me-central-1', 'me-south-1', 'sa-east-1',
'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2'.

During handling of the above exception, another exception occurred:

╭──────────────────────────────────────────────────────────────────────────────────────────────────── Traceback (most recent call last) ─────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ /Users/rporresm/.local/bin/rh-aws-saml-login:8 in <module>                                                                                                                                                                                 │
│                                                                                                                                                                                                                                            │
│   5 from rh_aws_saml_login.__main__ import app                                               ╭───────────────────────────────────────────────────────────── locals ──────────────────────────────────────────────────────────────╮         │
│   6 if __name__ == "__main__":                                                               │ app = <typer.main.Typer object at 0x107e8a120>                                                                                    │         │
│   7 │   sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])                     │  re = <module 're' from '/Users/rporresm/.local/share/uv/python/cpython-3.13.1-macos-aarch64-none/lib/python3.13/re/__init__.py'> │         │
│ ❱ 8 │   sys.exit(app())                                                                      │ sys = <module 'sys' (built-in)>                                                                                                   │         │
│   9                                                                                          ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯         │
│                                                                                                                                                                                                                                            │
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/typer/main.py:340 in __call__                                                                                                                         │
│                                                                                                                                                                                                                                            │
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/typer/main.py:323 in __call__                                                                                                                         │
│                                                                                                                                                                                                                                            │
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/click/core.py:1442 in __call__                                                                                                                        │
│                                                                                                                                                                                                                                            │
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/typer/core.py:677 in main                                                                                                                             │
│                                                                                                                                                                                                                                            │
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/typer/core.py:216 in _main                                                                                                                            │
│                                                                                                                                                                                                                                            │
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/typer/rich_utils.py:693 in rich_format_error                                                                                                          │
│                                                                                                                                                                                                                                            │
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/click/core.py:724 in get_usage                                                                                                                        │
│                                                                                                                                                                                                                                            │
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/click/core.py:969 in get_usage                                                                                                                        │
│                                                                                                                                                                                                                                            │
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/click/core.py:1002 in format_usage                                                                                                                    │
│                                                                                                                                                                                                                                            │
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/click/core.py:1012 in collect_usage_pieces                                                                                                            │
│                                                                                                                                                                                                                                            │
│ /Users/rporresm/.local/share/uv/tools/rh-aws-saml-login/lib/python3.13/site-packages/click/core.py:3104 in get_usage_pieces                                                                                                                │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: TyperArgument.make_metavar() takes 1 positional argument but 2 were given