### PR TITLE
:bug: single AWS account support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.10.1
+
+### Bug Fixes
+
+* Fix `No AWS accounts found` exception when the user has access to only one account. #409
+
+### Chore
+
+* Upgrade dependencies
+
 ## 0.10.0
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rh-aws-saml-login"
-version = "0.10.0"
+version = "0.10.1"
 description = "A CLI tool that allows you to log in and retrieve AWS temporary credentials using Red Hat SAML IDP"
 authors = [{ name = "Christian Assing", email = "cassing@redhat.com" }]
 license = { text = "MIT License" }

--- a/rh_aws_saml_login/_models.py
+++ b/rh_aws_saml_login/_models.py
@@ -8,8 +8,8 @@ class AwsAccount:
     uid: str
     role_name: str
     role_arn: str
-    session_timeout_seconds: int
-    region: str
+    session_timeout_seconds: int = 3600
+    region: str = "us-east-1"
 
     @property
     def principle_arn(self) -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 
 [[package]]
@@ -570,7 +570,7 @@ wheels = [
 
 [[package]]
 name = "rh-aws-saml-login"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Support user has access to only one AWS account.

Fixes #409 