### PR TITLE
chore: drop explicit click dependency, upgrade typer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.15.1
+
+### Chore
+
+* Upgrade typer to >=0.26.7 and drop explicit `click` dependency (now bundled with typer)
+
 ## 0.15.0
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rh-aws-saml-login"
-version = "0.15.0"
+version = "0.15.1"
 description = "A CLI tool that allows you to log in and retrieve AWS temporary credentials using Red Hat SAML IDP"
 authors = [{ name = "Christian Assing", email = "cassing@redhat.com" }]
 license = { text = "MIT License" }
@@ -15,13 +15,12 @@ classifiers = [
 requires-python = ">= 3.12"
 dependencies = [
     "boto3>=1.35.33",
-    "click<8.4.0",
     "humanize>=4.10.0",
     "iterfzf>=1.4.0.54.3",
     "pyquery>=2.0.1",
     "requests-gssapi>=1.4.0",
     "rich>=13.9.1",
-    "typer>=0.16.0",
+    "typer>=0.26.7",
     "tzlocal>=5.2",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -166,18 +166,6 @@ wheels = [
 ]
 
 [[package]]
-name = "click"
-version = "8.3.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -608,11 +596,10 @@ wheels = [
 
 [[package]]
 name = "rh-aws-saml-login"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
-    { name = "click" },
     { name = "humanize" },
     { name = "iterfzf" },
     { name = "pyquery" },
@@ -635,13 +622,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.35.33" },
-    { name = "click", specifier = "<8.4.0" },
     { name = "humanize", specifier = ">=4.10.0" },
     { name = "iterfzf", specifier = ">=1.4.0.54.3" },
     { name = "pyquery", specifier = ">=2.0.1" },
     { name = "requests-gssapi", specifier = ">=1.4.0" },
     { name = "rich", specifier = ">=13.9.1" },
-    { name = "typer", specifier = ">=0.16.0" },
+    { name = "typer", specifier = ">=0.26.7" },
     { name = "tzlocal", specifier = ">=5.2" },
 ]
 


### PR DESCRIPTION
## Summary

- Upgrade typer from `>=0.16.0` to `>=0.26.7` which bundles click internally
- Remove the explicit `click<8.4.0` dependency pin — no longer needed
- Bump version to 0.15.1

## Test plan

- [x] `uv run rh-aws-saml-login --help` works
- [x] All existing tests pass